### PR TITLE
Allows more granular config for an existing installation of Lake/Lean/REPL

### DIFF
--- a/src/lean_interact/config.py
+++ b/src/lean_interact/config.py
@@ -234,8 +234,7 @@ class TempRequireProject(BaseTempProject):
         with open(os.path.join(project_dir, "lakefile.lean"), "a", encoding="utf-8") as f:
             for req in require:
                 f.write(f'\n\nrequire {req.name} from git\n  "{req.git}"' + (f' @ "{req.rev}"' if req.rev else ""))
-
-
+            
 class LeanREPLConfig:
     def __init__(
         self,
@@ -249,6 +248,8 @@ class LeanREPLConfig:
         setup: bool = True,
         lake_env_repl_path : str | None = None,
         working_dir : str | None = None,
+        lake_path : str = "lake",
+        lake_command : str = "env",
     ):
         """
         Initialize the Lean REPL configuration.
@@ -323,6 +324,8 @@ class LeanREPLConfig:
             self._working_dir = self.project._get_directory(cache_dir=self.cache_dir, lean_version=self.lean_version)
         
         self.lake_env_repl_path = lake_env_repl_path or os.path.join(self._cache_repl_dir, ".lake", "build", "bin", "repl")
+        self.lake_path = lake_path
+        self.lake_command = lake_command
 
     def _setup_repl(self) -> None:
         from git import GitCommandError, Repo

--- a/src/lean_interact/config.py
+++ b/src/lean_interact/config.py
@@ -312,7 +312,7 @@ class LeanREPLConfig:
 
         if working_dir:
             self._working_dir = working_dir
-        if self.project is None:
+        elif self.project is None:
             self._working_dir = self._cache_repl_dir
         else:
             self.project._instantiate(
@@ -394,7 +394,7 @@ class LeanREPLConfig:
         """
         Get the available Lean versions for the selected REPL.
         """
-        from git Repo
+        from git import Repo
         repo = Repo(self.cache_clean_repl_dir)
         return [
             (str(commit.message.strip()), commit.hexsha)

--- a/src/lean_interact/server.py
+++ b/src/lean_interact/server.py
@@ -134,6 +134,7 @@ class LeanServer:
                     line = self._proc.stdout.readline()
                     if not line:
                         break  # EOF
+                    print(repr(line))
                     output += line
                     if output.endswith("\n\n"):
                         break

--- a/src/lean_interact/server.py
+++ b/src/lean_interact/server.py
@@ -63,7 +63,7 @@ class LeanServer:
 
     def start(self) -> None:
         self._proc = subprocess.Popen(
-            ["lake", "env", self.config.lake_env_repl_path],
+            [self.config.lake_path, self.config.lake_command, self.config.lake_env_repl_path],
             cwd=self.config.working_dir,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -121,7 +121,8 @@ class LeanServer:
         with self._lock:
             if verbose:
                 logger.info("Sending query: %s", json_query)
-            self._proc.stdin.write(json_query + "\n\n")
+            print(json_query)
+            self._proc.stdin.write(json_query + "\n\n\n\n")
             self._proc.stdin.flush()
 
             output: str = ""
@@ -134,7 +135,6 @@ class LeanServer:
                     line = self._proc.stdout.readline()
                     if not line:
                         break  # EOF
-                    print(repr(line))
                     output += line
                     if output.endswith("\n\n"):
                         break

--- a/src/lean_interact/server.py
+++ b/src/lean_interact/server.py
@@ -121,7 +121,6 @@ class LeanServer:
         with self._lock:
             if verbose:
                 logger.info("Sending query: %s", json_query)
-            print(json_query)
             self._proc.stdin.write(json_query + "\n\n\n\n")
             self._proc.stdin.flush()
 

--- a/src/lean_interact/server.py
+++ b/src/lean_interact/server.py
@@ -63,7 +63,7 @@ class LeanServer:
 
     def start(self) -> None:
         self._proc = subprocess.Popen(
-            ["lake", "env", os.path.join(self.config._cache_repl_dir, ".lake", "build", "bin", "repl")],
+            ["lake", "env", self.config.lake_env_repl_path],
             cwd=self.config.working_dir,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
No docs yet for the new arguments

```python
import os
from lean_interact import LeanREPLConfig, LeanServer, Command

# config = LeanREPLConfig(verbose=True) # download and build Lean REPL
config = LeanREPLConfig(
    lean_version = '',
    setup = False,
    lake_env_repl_path = 'repl',
    lake_command = 'exe',
    lake_path = os.path.expanduser('~/.elan/bin/lake'),
    working_dir = os.path.expanduser('~/mathlib4')
)

server = LeanServer(config)
print(server.run(Command(cmd="theorem ex (n : Nat) : n = 5 → n = 5 := id")))
``` 