### PR TITLE
Separate the session cache from AutoLeanServer

### DIFF
--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -18,14 +18,6 @@ This page documents the server classes responsible for communicating with the Le
       show_source: true
       heading_level: 3
 
-## Session State Helper
-
-::: lean_interact.server._SessionState
-    options:
-      show_root_heading: true
-      show_source: true
-      heading_level: 3
-
 ## Timeout Configuration
 
 ::: lean_interact.server.DEFAULT_TIMEOUT

--- a/docs/api/sessioncache.md
+++ b/docs/api/sessioncache.md
@@ -1,0 +1,52 @@
+# Session Cache API
+
+This page documents the session cache classes responsible for storing and retrieving Lean proof states and environments.
+Session cache is used internally by the `AutoLeanServer` class.
+It enables efficient resumption of proofs and environments after server restarts, timeouts, and automated recover from crashes. While by default `AutoLeanServer` instantiates a fresh `LeanServer` instance, you can also use a custom one. It can be useful to share a session cache between multiple `LeanServer` instances, or to use a custom session cache implementation.
+
+```python
+from lean_interact.sessioncache import PickleSessionCache
+from lean_interact.server import LeanServer
+
+# Create a session cache
+cache = PickleSessionCache(working_dir="./cache")
+
+# Create a Lean server with the cache
+server = LeanServer(session_cache=cache)
+```
+
+## Session State Classes
+
+### SessionState
+
+::: lean_interact.sessioncache.SessionState
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3
+
+### PickleSessionState
+
+::: lean_interact.sessioncache.PickleSessionState
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3
+
+## Cache Implementation
+
+### BaseSessionCache
+
+::: lean_interact.sessioncache.BaseSessionCache
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3
+
+### PickleSessionCache
+
+::: lean_interact.sessioncache.PickleSessionCache
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3

--- a/docs/api/sessioncache.md
+++ b/docs/api/sessioncache.md
@@ -2,7 +2,7 @@
 
 This page documents the session cache classes responsible for storing and retrieving Lean proof states and environments.
 Session cache is used internally by the `AutoLeanServer` class.
-It enables efficient resumption of proofs and environments after server restarts, timeouts, and automated recover from crashes. While by default `AutoLeanServer` instantiates a fresh `LeanServer` instance, you can also use a custom one. It can be useful to share a session cache between multiple `LeanServer` instances, or to use a custom session cache implementation.
+It enables efficient resumption of proofs and environments after server restarts, timeouts, and automated recover from crashes. While by default `AutoLeanServer` instantiates a fresh `PickleSessionCache` instance, you can also use a custom one. It can be useful to share a session cache between multiple `LeanServer` instances, or to use a custom session cache implementation.
 
 ```python
 from lean_interact.sessioncache import PickleSessionCache

--- a/docs/api/sessioncache.md
+++ b/docs/api/sessioncache.md
@@ -2,17 +2,17 @@
 
 This page documents the session cache classes responsible for storing and retrieving Lean proof states and environments.
 Session cache is used internally by the `AutoLeanServer` class.
-It enables efficient resumption of proofs and environments after server restarts, timeouts, and automated recover from crashes. While by default `AutoLeanServer` instantiates a fresh `PickleSessionCache` instance, you can also use a custom one. It can be useful to share a session cache between multiple `LeanServer` instances, or to use a custom session cache implementation.
+It enables efficient resumption of proofs and environments after server restarts, timeouts, and automated recover from crashes. While by default `AutoLeanServer` instantiates a fresh `PickleSessionCache` instance, you can also use a custom one. It can be useful to share a session cache between multiple `AutoLeanServer` instances, or to use a custom session cache implementation.
 
 ```python
 from lean_interact.sessioncache import PickleSessionCache
-from lean_interact.server import LeanServer
+from lean_interact.server import AutoLeanServer
 
 # Create a session cache
 cache = PickleSessionCache(working_dir="./cache")
 
 # Create a Lean server with the cache
-server = LeanServer(session_cache=cache)
+server = AutoLeanServer(config=..., session_cache=cache)
 ```
 
 ## Session State Classes

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,6 +23,7 @@ Install the package in development mode:
 - Include **type hints** where appropriate.
 - Follow the **existing code structure**.
 - Write **unit tests** for new features.
+- Update the **documentation** if necessary.
 
 ## Submitting Contributions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,15 +78,15 @@ plugins:
             show_category_heading: true
             members_order: source
   - execute:
-      execute_without_tag: []  # Don't execute any files by default
+      execute_without_tag: [] # Don't execute any files by default
       include:
-        - '*.md'
+        - "*.md"
       exclude: []
       tags:
-        execute: 'execute'
-        hide_cell: 'hide-cell'
-        hide_input: 'hide-input'
-        hide_output: 'hide-output'
+        execute: "execute"
+        hide_cell: "hide-cell"
+        hide_input: "hide-input"
+        hide_output: "hide-output"
 
 markdown_extensions:
   - pymdownx.highlight:
@@ -113,15 +113,16 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - User Guide:
-    - Getting Started: user-guide/getting-started.md
-    - Basic Usage: user-guide/basic-usage.md
-    - Tactic Mode: user-guide/tactic-mode.md
-    - Custom Lean Configuration: user-guide/custom-lean-configuration.md
+      - Getting Started: user-guide/getting-started.md
+      - Basic Usage: user-guide/basic-usage.md
+      - Tactic Mode: user-guide/tactic-mode.md
+      - Custom Lean Configuration: user-guide/custom-lean-configuration.md
   - API Reference:
-    - LeanREPLConfig: api/config.md
-    - LeanServer: api/server.md
-    - Interface: api/interface.md
-    - Utils: api/utils.md
+      - LeanREPLConfig: api/config.md
+      - LeanServer: api/server.md
+      - Session Cache: api/sessioncache.md
+      - Interface: api/interface.md
+      - Utils: api/utils.md
   - Examples: examples.md
   - Troubleshooting: troubleshooting.md
   - Contributing: contributing.md

--- a/src/lean_interact/server.py
+++ b/src/lean_interact/server.py
@@ -1,13 +1,11 @@
 import asyncio
 import gc
-import hashlib
 import json
 import os
 import platform
 import subprocess
 import threading
 from copy import deepcopy
-from dataclasses import dataclass
 from time import sleep
 from typing import overload
 
@@ -30,6 +28,7 @@ from lean_interact.interface import (
     UnpickleProofState,
 )
 from lean_interact.utils import _limit_memory, get_total_memory_usage, logger
+from lean_interact.sessioncache import BaseSessionCache, DictSessionCache
 
 DEFAULT_TIMEOUT: int | None = None
 
@@ -278,13 +277,6 @@ class LeanServer:
         return await asyncio.to_thread(self.run, request, verbose=verbose, timeout=timeout, **kwargs)  # type: ignore
 
 
-@dataclass
-class _SessionState:
-    session_id: int
-    repl_id: int
-    pickle_file: str
-    is_proof_state: bool
-
 
 class AutoLeanServer(LeanServer):
     def __init__(
@@ -293,6 +285,7 @@ class AutoLeanServer(LeanServer):
         max_total_memory: float = 0.8,
         max_process_memory: float | None = 0.8,
         max_restart_attempts: int = 5,
+        session_cache: BaseSessionCache | None = None,
     ):
         """
         This class is a Python wrapper for the Lean REPL. `AutoLeanServer` differs from `LeanServer` by automatically \
@@ -321,9 +314,10 @@ class AutoLeanServer(LeanServer):
             max_total_memory: The maximum proportion of system-wide memory usage (across all processes) before triggering a Lean server restart. This is a soft limit ranging from 0.0 to 1.0, with default 0.8 (80%). When system memory exceeds this threshold, the server restarts to free memory. Particularly useful in multiprocessing environments to prevent simultaneous crashes.
             max_process_memory: The maximum proportion of the memory hard limit (set in `LeanREPLConfig.memory_hard_limit_mb`) that the Lean server process can use before restarting. This soft limit ranges from 0.0 to 1.0, with default 0.8 (80%). Only applied if a hard limit is configured in `LeanREPLConfig`.
             max_restart_attempts: The maximum number of consecutive restart attempts allowed before raising a `MemoryError` exception. Default is 5. The server uses exponential backoff between restart attempts.
+            session_cache: The session cache to use, if specified.
         """
-        self._state_counter = 0
-        self._restart_persistent_session_cache: dict[int, _SessionState] = {}
+        session_cache = session_cache if session_cache is not None else DictSessionCache(working_dir=self.config.working_dir)
+        self._session_cache = session_cache
         self._max_total_memory = max_total_memory
         self._max_process_memory = max_process_memory
         self._max_restart_attempts = max_restart_attempts
@@ -332,15 +326,15 @@ class AutoLeanServer(LeanServer):
     def _get_repl_state_id(self, state_id: int | None) -> int | None:
         if state_id is None:
             return None
-        if state_id >= 0:
-            return state_id
-        return self._restart_persistent_session_cache[state_id].repl_id
+        if state_id in self._session_cache:
+            return self._session_cache[state_id].repl_id
+        return state_id
 
     def _reload_session_cache(self, verbose: bool = False) -> None:
         """
         Reload the session cache. This method should be called only after a restart of the Lean REPL.
         """
-        for state_data in self._restart_persistent_session_cache.values():
+        for state_data in self._session_cache:
             # Use file lock when accessing the pickle file to prevent cache invalidation
             # from multiple concurrent processes
             with FileLock(f"{state_data.pickle_file}.lock", timeout=60):
@@ -378,11 +372,7 @@ class AutoLeanServer(LeanServer):
         Args:
             session_state_id: The session state id to remove.
         """
-        if (state_cache := self._restart_persistent_session_cache.pop(session_state_id, None)) is not None:
-            pickle_file = state_cache.pickle_file
-            with FileLock(f"{pickle_file}.lock", timeout=60):
-                if os.path.exists(pickle_file):
-                    os.remove(pickle_file)
+        self._session_cache.remove(session_state_id)
 
     def clear_session_cache(self, force: bool = False) -> None:
         """
@@ -393,55 +383,15 @@ class AutoLeanServer(LeanServer):
                 `force=False` will only clear the session cache the next time the server runs out of memory while \
                 still allowing you to add new content in the session cache in the meantime.
         """
-        states_data = list(self._restart_persistent_session_cache.values())
-        for state_data in states_data:
-            self.remove_from_session_cache(session_state_id=state_data.session_id)
-        self._restart_persistent_session_cache = {}
+        self._session_cache.clear()
         if force:
             self.restart()
 
     def __del__(self):
         # delete the session cache
-        for state_data in self._restart_persistent_session_cache.values():
-            try:
-                os.remove(state_data.pickle_file)
-            except FileNotFoundError:
-                pass
-
+        self._session_cache.clear()
         super().__del__()
 
-    def _store_session_cache(
-        self, hash_key: str, repl_id: int, is_proof_state: bool = False, verbose: bool = False
-    ) -> int:
-        self._state_counter -= 1
-        process_id = os.getpid()  # use process id to avoid conflicts in multiprocessing
-        pickle_file = os.path.join(
-            self.config.working_dir,
-            f"session_cache/{hashlib.sha256(hash_key.encode()).hexdigest()}_{process_id}.olean",
-        )
-        os.makedirs(os.path.dirname(pickle_file), exist_ok=True)
-        if is_proof_state:
-            request = PickleProofState(proof_state=repl_id, pickle_to=pickle_file)
-        else:
-            request = PickleEnvironment(env=repl_id, pickle_to=pickle_file)
-
-        # Use file lock when accessing the pickle file to prevent cache invalidation
-        # from multiple concurrent processes
-        with FileLock(f"{pickle_file}.lock", timeout=60):
-            result = self.run(request, verbose=verbose, timeout=DEFAULT_TIMEOUT)
-            if isinstance(result, LeanError):
-                raise ValueError(
-                    f"Could not store the result in the session cache. The Lean server returned an error: {result.message}"
-                )
-
-            self._restart_persistent_session_cache[self._state_counter] = _SessionState(
-                session_id=self._state_counter,
-                repl_id=repl_id,
-                pickle_file=pickle_file,
-                is_proof_state=is_proof_state,
-            )
-
-        return self._state_counter
 
     def _run_dict_backoff(self, request: dict, verbose: bool, timeout: float | None, restart_counter: int = 0) -> dict:
         if (psutil.virtual_memory().percent >= 100 * self._max_total_memory) or (
@@ -543,18 +493,14 @@ class AutoLeanServer(LeanServer):
             if add_to_session_cache:
                 env_id = result.env
                 hash_key = f"request_{type(request).__name__}_{id(request)}"
-                new_env_id = self._store_session_cache(
-                    hash_key=hash_key, repl_id=env_id, is_proof_state=False, verbose=verbose
-                )
+                new_env_id = self._session_cache.add(self, hash_key, env_id, is_proof_state=False, verbose=verbose)
                 result = result.model_copy(update={"env": new_env_id})
         elif isinstance(request, (ProofStep, PickleProofState, UnpickleProofState)):
             result = ProofStepResponse.model_validate(result_dict)
             if add_to_session_cache:
                 proof_state_id = result.proof_state
                 hash_key = f"proofstep_{type(request).__name__}_{id(request)}"
-                new_proof_state_id = self._store_session_cache(
-                    hash_key=hash_key, repl_id=proof_state_id, is_proof_state=True, verbose=verbose
-                )
+                new_proof_state_id = self._session_cache.add(self, hash_key, proof_state_id, is_proof_state=True, verbose=verbose)
                 result = result.model_copy(update={"proofState": new_proof_state_id})
         else:
             result = BaseREPLResponse.model_validate(result_dict)

--- a/src/lean_interact/server.py
+++ b/src/lean_interact/server.py
@@ -28,7 +28,7 @@ from lean_interact.interface import (
     UnpickleProofState,
 )
 from lean_interact.utils import _limit_memory, get_total_memory_usage, logger
-from lean_interact.sessioncache import BaseSessionCache, DictSessionCache
+from lean_interact.sessioncache import BaseSessionCache, PickleSessionCache
 
 DEFAULT_TIMEOUT: int | None = None
 
@@ -316,8 +316,8 @@ class AutoLeanServer(LeanServer):
             max_restart_attempts: The maximum number of consecutive restart attempts allowed before raising a `MemoryError` exception. Default is 5. The server uses exponential backoff between restart attempts.
             session_cache: The session cache to use, if specified.
         """
-        session_cache = session_cache if session_cache is not None else DictSessionCache(working_dir=self.config.working_dir)
-        self._session_cache = session_cache
+        session_cache = session_cache if session_cache is not None else PickleSessionCache(working_dir=config.working_dir)
+        self._session_cache: BaseSessionCache = session_cache
         self._max_total_memory = max_total_memory
         self._max_process_memory = max_process_memory
         self._max_restart_attempts = max_restart_attempts

--- a/src/lean_interact/sessioncache.py
+++ b/src/lean_interact/sessioncache.py
@@ -1,0 +1,112 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from os import PathLike
+import os
+from typing import Iterator, Any
+from filelock import FileLock
+import hashlib
+from lean_interact.interface import PickleProofState, PickleEnvironment, LeanError
+
+
+@dataclass
+class SessionState:
+    session_id: int
+    repl_id: int
+    pickle_file: str
+    is_proof_state: bool
+
+
+class BaseSessionCache(ABC):
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def add(self, server, hash_key: str, repl_id: int, is_proof_state: bool = False, verbose: bool = False) -> int:
+        """Add a new item into the session cache.
+
+        Will either be a request or a proof state.
+
+        Returns an identifier session_state_id, that can be used to access or remove the item."""
+        pass
+
+    @abstractmethod
+    def remove(self, session_state_id: int, verbose: bool = False) -> None:
+        """Remove an item from the session cache."""
+        pass
+
+    @abstractmethod
+    def clear(self, verbose: bool = False) -> None:
+        pass
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[SessionState]:
+        pass
+
+    @abstractmethod
+    def __contains__(self, item: Any) -> bool:
+        pass
+
+    @abstractmethod
+    def __getitem__(self, item: Any) -> SessionState:
+        pass
+
+
+class DictSessionCache(BaseSessionCache):
+    """A session cache based on the local file storage.
+
+    Will maintain a separate session cache per server."""
+    def __init__(self, working_dir: str | PathLike):
+        self._cache: dict[int, SessionState] = {}
+        self._state_counter = 0
+        self._working_dir = working_dir
+
+    def add(self, server, hash_key: str, repl_id: int, is_proof_state: bool = False, verbose: bool = False) -> None:
+        self._state_counter -= 1
+        process_id = os.getpid()  # use process id to avoid conflicts in multiprocessing
+        pickle_file = os.path.join(
+            self._working_dir,
+            f"session_cache/{hashlib.sha256(hash_key.encode()).hexdigest()}_{process_id}.olean",
+        )
+        os.makedirs(os.path.dirname(pickle_file), exist_ok=True)
+        if is_proof_state:
+            request = PickleProofState(proof_state=repl_id, pickle_to=pickle_file)
+        else:
+            request = PickleEnvironment(env=repl_id, pickle_to=pickle_file)
+
+        # Use file lock when accessing the pickle file to prevent cache invalidation
+        # from concurrent access
+        with FileLock(f"{pickle_file}.lock", timeout=60):
+            result = server.run(request, verbose=verbose)
+            if isinstance(result, LeanError):
+                raise ValueError(
+                    f"Could not store the result in the session cache. The Lean server returned an error: {result.message}"
+                )
+
+            self._cache[self._state_counter] = SessionState(
+                session_id=self._state_counter,
+                repl_id=repl_id,
+                pickle_file=pickle_file,
+                is_proof_state=is_proof_state,
+            )
+
+    def remove(self, session_state_id: int, verbose: bool = False) -> None:
+        if (state_cache := self._cache.pop(session_state_id, None)) is not None:
+            pickle_file = state_cache.pickle_file
+            with FileLock(f"{pickle_file}.lock", timeout=60):
+                if os.path.exists(pickle_file):
+                    os.remove(pickle_file)
+
+    def clear(self, verbose: bool = False) -> None:
+        for state_data in self:
+            self.remove(session_state_id=state_data.session_id)
+        assert not self._cache
+
+    def __iter__(self) -> Iterator[SessionState]:
+        return iter(self._cache.values())
+
+    def __contains__(self, item: Any) -> bool:
+        return item in self._cache
+
+    def __getitem__(self, item: Any) -> SessionState:
+        return self._cache[item]

--- a/src/lean_interact/sessioncache.py
+++ b/src/lean_interact/sessioncache.py
@@ -1,89 +1,141 @@
+import hashlib
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from os import PathLike
-import os
-from typing import Iterator, Any
+from typing import Iterator
+
 from filelock import FileLock
-import hashlib
-from lean_interact.interface import PickleProofState, PickleEnvironment, LeanError
+
+from lean_interact.interface import (
+    BaseREPLQuery,
+    BaseREPLResponse,
+    CommandResponse,
+    LeanError,
+    PickleEnvironment,
+    PickleProofState,
+    ProofStepResponse,
+    UnpickleEnvironment,
+    UnpickleProofState,
+)
 
 
 @dataclass
 class SessionState:
     session_id: int
     repl_id: int
-    pickle_file: str
     is_proof_state: bool
 
 
 class BaseSessionCache(ABC):
     @abstractmethod
     def __init__(self):
-        pass
+        """Initialize the session cache."""
 
     @abstractmethod
-    def add(self, server, hash_key: str, repl_id: int, is_proof_state: bool = False, verbose: bool = False) -> int:
+    def add(self, lean_server, request: BaseREPLQuery, response: BaseREPLResponse, verbose: bool = False) -> int:
         """Add a new item into the session cache.
-
-        Will either be a request or a proof state.
-
-        Returns an identifier session_state_id, that can be used to access or remove the item."""
-        pass
+        Args:
+            lean_server: The Lean server to use.
+            request: The request to send to the Lean server.
+            response: The response from the Lean server.
+            verbose: Whether to print verbose output.
+        Returns:
+            An identifier session_state_id, that can be used to access or remove the item.
+        """
 
     @abstractmethod
     def remove(self, session_state_id: int, verbose: bool = False) -> None:
-        """Remove an item from the session cache."""
-        pass
+        """Remove an item from the session cache.
+        Args:
+            session_state_id: The identifier of the item to remove.
+            verbose: Whether to print verbose output.
+        """
 
     @abstractmethod
-    def clear(self, verbose: bool = False) -> None:
-        pass
+    def reload(self, lean_server, timeout_per_state: int | float | None, verbose: bool = False) -> None:
+        """Reload the session cache.
+        This is useful when the Lean server has been restarted and the session cache
+        needs to be reloaded.
+
+        Args:
+            lean_server: The Lean server to use.
+            timeout_per_state: The timeout for each state in seconds.
+            verbose: Whether to print verbose output.
+        """
 
     @abstractmethod
-    def __iter__(self) -> Iterator[SessionState]:
-        pass
+    def is_empty(self) -> bool:
+        """Check if the session cache is empty."""
 
     @abstractmethod
-    def __contains__(self, item: Any) -> bool:
-        pass
+    def clear(self, verbose: bool = False) -> None: ...
 
     @abstractmethod
-    def __getitem__(self, item: Any) -> SessionState:
-        pass
+    def __iter__(self) -> Iterator[SessionState]: ...
+
+    @abstractmethod
+    def __contains__(self, session_id: int) -> bool: ...
+
+    @abstractmethod
+    def __getitem__(self, session_id: int) -> SessionState: ...
+
+    @abstractmethod
+    def keys(self) -> list[int]:
+        """Get all keys (session state IDs) currently in the cache.
+
+        Returns:
+            A list of all session state IDs.
+        """
+
+
+@dataclass
+class PickleSessionState(SessionState):
+    pickle_file: str
 
 
 class PickleSessionCache(BaseSessionCache):
-    """A session cache based on the local file storage.
+    """A session cache based on the local file storage and the REPL pickle feature.
 
     Will maintain a separate session cache per server."""
+
     def __init__(self, working_dir: str | PathLike):
-        self._cache: dict[int, SessionState] = {}
+        self._cache: dict[int, PickleSessionState] = {}
         self._state_counter = 0
         self._working_dir = working_dir
 
-    def add(self, server, hash_key: str, repl_id: int, is_proof_state: bool = False, verbose: bool = False) -> int:
+    def add(self, lean_server, request: BaseREPLQuery, response: BaseREPLResponse, verbose: bool = False) -> int:
         self._state_counter -= 1
         process_id = os.getpid()  # use process id to avoid conflicts in multiprocessing
+        hash_key = f"request_{type(request).__name__}_{id(request)}"
         pickle_file = os.path.join(
             self._working_dir,
             f"session_cache/{hashlib.sha256(hash_key.encode()).hexdigest()}_{process_id}.olean",
         )
         os.makedirs(os.path.dirname(pickle_file), exist_ok=True)
-        if is_proof_state:
-            request = PickleProofState(proof_state=repl_id, pickle_to=pickle_file)
+        if isinstance(response, ProofStepResponse):
+            repl_id = response.proof_state
+            is_proof_state = True
+            request = PickleProofState(proof_state=response.proof_state, pickle_to=pickle_file)
+        elif isinstance(response, CommandResponse):
+            repl_id = response.env
+            is_proof_state = False
+            request = PickleEnvironment(env=response.env, pickle_to=pickle_file)
         else:
-            request = PickleEnvironment(env=repl_id, pickle_to=pickle_file)
+            raise NotImplementedError(
+                f"Cannot pickle the session state for unsupported request of type {type(request).__name__}."
+            )
 
         # Use file lock when accessing the pickle file to prevent cache invalidation
         # from concurrent access
         with FileLock(f"{pickle_file}.lock", timeout=60):
-            result = server.run(request, verbose=verbose)
-            if isinstance(result, LeanError):
+            response = lean_server.run(request, verbose=verbose)
+            if isinstance(response, LeanError):
                 raise ValueError(
-                    f"Could not store the result in the session cache. The Lean server returned an error: {result.message}"
+                    f"Could not store the result in the session cache. The Lean server returned an error: {response.message}"
                 )
 
-            self._cache[self._state_counter] = SessionState(
+            self._cache[self._state_counter] = PickleSessionState(
                 session_id=self._state_counter,
                 repl_id=repl_id,
                 pickle_file=pickle_file,
@@ -98,16 +150,54 @@ class PickleSessionCache(BaseSessionCache):
                 if os.path.exists(pickle_file):
                     os.remove(pickle_file)
 
+    def reload(self, lean_server, timeout_per_state: int | float | None, verbose: bool = False) -> None:
+        """
+        Reload the session cache. This method should be called only after a restart of the Lean REPL.
+        """
+        for state_data in self:
+            # Use file lock when accessing the pickle file to prevent cache invalidation
+            # from multiple concurrent processes
+            with FileLock(
+                f"{state_data.pickle_file}.lock", timeout=float(timeout_per_state) if timeout_per_state else -1
+            ):
+                if state_data.is_proof_state:
+                    cmd = UnpickleProofState(unpickle_proof_state_from=state_data.pickle_file, env=state_data.repl_id)
+                else:
+                    cmd = UnpickleEnvironment(unpickle_env_from=state_data.pickle_file)
+                result = lean_server.run(
+                    cmd,
+                    verbose=verbose,
+                    timeout=timeout_per_state,
+                )
+                if isinstance(result, LeanError):
+                    raise ValueError(
+                        f"Could not reload the session cache. The Lean server returned an error: {result.message}"
+                    )
+                elif isinstance(result, CommandResponse):
+                    state_data.repl_id = result.env
+                elif isinstance(result, ProofStepResponse):
+                    state_data.repl_id = result.proof_state
+                else:
+                    raise ValueError(
+                        f"Could not reload the session cache. The Lean server returned an unexpected response: {result}"
+                    )
+
+    def is_empty(self) -> bool:
+        return len(self._cache) == 0
+
     def clear(self, verbose: bool = False) -> None:
         for state_data in list(self):
-            self.remove(session_state_id=state_data.session_id)
+            self.remove(session_state_id=state_data.session_id, verbose=verbose)
         assert not self._cache
 
-    def __iter__(self) -> Iterator[SessionState]:
+    def __iter__(self) -> Iterator[PickleSessionState]:
         return iter(self._cache.values())
 
-    def __contains__(self, item: Any) -> bool:
-        return item in self._cache
+    def __contains__(self, session_id: int) -> bool:
+        return session_id in self._cache
 
-    def __getitem__(self, item: Any) -> SessionState:
-        return self._cache[item]
+    def __getitem__(self, session_id: int) -> PickleSessionState:
+        return self._cache[session_id]
+
+    def keys(self) -> list[int]:
+        return list(self._cache.keys())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,9 +36,9 @@ from lean_interact.interface import (
 from lean_interact.server import (
     DEFAULT_TIMEOUT,
     AutoLeanServer,
-    LeanServer,
-    _SessionState,
+    LeanServer
 )
+from lean_interact.sessioncache import SessionState
 
 
 class TestLeanServer(unittest.TestCase):
@@ -212,7 +212,7 @@ lean_exe "dummy" where
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True))
         server.run(Command(cmd="def x := 1"), add_to_session_cache=True, verbose=True)
         server.clear_session_cache()
-        self.assertEqual(len(server._restart_persistent_session_cache), 0)
+        self.assertEqual(len(server._session_cache._cache), 0)
 
     def test_init_with_invalid_rev(self):
         with self.assertRaises(Exception):
@@ -315,7 +315,7 @@ lean_exe "dummy" where
         server.restart()
         result = server.run(Command(cmd="noncomputable def y := x + 1", env=env_id), verbose=True)
         self.assertEqual(result, CommandResponse(env=1))
-        self.assertEqual(list(server._restart_persistent_session_cache.keys()), [env_id])
+        self.assertEqual(list(server._session_cache._cache.keys()), [env_id])
 
     def test_process_request_memory_restart(self):
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True), max_total_memory=0.01, max_restart_attempts=2)
@@ -331,7 +331,7 @@ lean_exe "dummy" where
     def test_process_request_with_negative_env_id(self, mock_super):
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True))
         # Prepare restart_persistent_session_cache
-        server._restart_persistent_session_cache[-1] = _SessionState(-1, 10, "", False)
+        server._session_cache._cache[-1] = SessionState(-1, 10, "", False)
         with unittest.mock.patch.object(server, "_get_repl_state_id", return_value=10):
             mock_super.return_value = {"env": 10}
             result = server.run(Command(cmd="test", env=-1))
@@ -342,7 +342,7 @@ lean_exe "dummy" where
     def test_process_request_with_negative_proof_state_id(self, mock_super):
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True))
         # Prepare restart_persistent_session_cache
-        server._restart_persistent_session_cache[-2] = _SessionState(-2, 20, "", True)
+        server._session_cache._cache[-1] = SessionState(-2, 20, "", True)
         with unittest.mock.patch.object(server, "_get_repl_state_id", return_value=20):
             mock_super.return_value = {"proofState": 20, "goals": [], "proofStatus": "Completed"}
             result = server.run(ProofStep(proof_state=-2, tactic="test"))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,12 +33,8 @@ from lean_interact.interface import (
     UnpickleEnvironment,
     UnpickleProofState,
 )
-from lean_interact.server import (
-    DEFAULT_TIMEOUT,
-    AutoLeanServer,
-    LeanServer
-)
-from lean_interact.sessioncache import SessionState
+from lean_interact.server import DEFAULT_TIMEOUT, AutoLeanServer, LeanServer
+from lean_interact.sessioncache import PickleSessionCache, PickleSessionState
 
 
 class TestLeanServer(unittest.TestCase):
@@ -212,7 +208,7 @@ lean_exe "dummy" where
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True))
         server.run(Command(cmd="def x := 1"), add_to_session_cache=True, verbose=True)
         server.clear_session_cache()
-        self.assertEqual(len(server._session_cache._cache), 0)
+        self.assertTrue(server._session_cache.is_empty())
 
     def test_init_with_invalid_rev(self):
         with self.assertRaises(Exception):
@@ -315,7 +311,7 @@ lean_exe "dummy" where
         server.restart()
         result = server.run(Command(cmd="noncomputable def y := x + 1", env=env_id), verbose=True)
         self.assertEqual(result, CommandResponse(env=1))
-        self.assertEqual(list(server._session_cache._cache.keys()), [env_id])
+        self.assertEqual(list(server._session_cache.keys()), [env_id])
 
     def test_process_request_memory_restart(self):
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True), max_total_memory=0.01, max_restart_attempts=2)
@@ -331,7 +327,8 @@ lean_exe "dummy" where
     def test_process_request_with_negative_env_id(self, mock_super):
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True))
         # Prepare restart_persistent_session_cache
-        server._session_cache._cache[-1] = SessionState(-1, 10, "", False)
+        assert isinstance(server._session_cache, PickleSessionCache)
+        server._session_cache._cache[-1] = PickleSessionState(-1, 10, False, "")
         with unittest.mock.patch.object(server, "_get_repl_state_id", return_value=10):
             mock_super.return_value = {"env": 10}
             result = server.run(Command(cmd="test", env=-1))
@@ -342,7 +339,8 @@ lean_exe "dummy" where
     def test_process_request_with_negative_proof_state_id(self, mock_super):
         server = AutoLeanServer(config=LeanREPLConfig(verbose=True))
         # Prepare restart_persistent_session_cache
-        server._session_cache._cache[-1] = SessionState(-2, 20, "", True)
+        assert isinstance(server._session_cache, PickleSessionCache)
+        server._session_cache._cache[-1] = PickleSessionState(-2, 20, True, "")
         with unittest.mock.patch.object(server, "_get_repl_state_id", return_value=20):
             mock_super.return_value = {"proofState": 20, "goals": [], "proofStatus": "Completed"}
             result = server.run(ProofStep(proof_state=-2, tactic="test"))


### PR DESCRIPTION
The current session cache implementation is inherently bound to AutoLeanServer. Though this is not necessarily a bad thing, I came across scenarios where a loose coupling would be nice. If I run many AutoLeanServers in parallel, I would like to have more control over what is cached and where it is cached, to be able to reuse cached environments across Lean servers. 
I simply moved the current implementation into a separate file and exposed a new parameter without modifying any method that is not marked as protected.