### PR TITLE
Check Lean version formatting

### DIFF
--- a/src/lean_interact/config.py
+++ b/src/lean_interact/config.py
@@ -323,6 +323,10 @@ class LeanREPLConfig:
                 Whether to print additional information during the setup process.
         """
         # Initialize basic configuration
+        if lean_version:
+            lean_version = lean_version.removeprefix("leanprover/lean4:")
+            if not lean_version.startswith("v4"):
+                raise ValueError("Unable to parse Lean version format!")
         self.lean_version = lean_version
         self.project = project
         self.repl_git = repl_git


### PR DESCRIPTION
I ran into this one way to often by now. If one inserts an incorrect Lean version, the git checkout fails, and a cryptic error message is raised. This might be a bit more user-friendly.